### PR TITLE
Remove linkedin links

### DIFF
--- a/index.html
+++ b/index.html
@@ -2381,7 +2381,7 @@
                     </div>
                     
                     <!-- Contact Cards Grid -->
-                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-6 mb-12">
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-12">
                         <!-- Email Card -->
                         <div class="group">
                             <div class="glass-card p-6 rounded-2xl bg-gradient-to-br from-indigo-50 to-cyan-50 dark:from-indigo-900/20 dark:to-cyan-900/20 border-2 border-transparent hover:border-indigo-200 dark:hover:border-indigo-700 transition-all duration-300 hover:scale-105 hover:shadow-xl">
@@ -2430,19 +2430,7 @@
                             </div>
                         </div>
                         
-                        <!-- LinkedIn Card -->
-                        <div class="group">
-                            <div class="glass-card p-6 rounded-2xl bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 border-2 border-transparent hover:border-blue-200 dark:hover:border-blue-700 transition-all duration-300 hover:scale-105 hover:shadow-xl">
-                                <div class="flex flex-col items-center text-center">
-                                    <div class="w-16 h-16 bg-gradient-to-br from-blue-600 to-indigo-500 rounded-full flex items-center justify-center text-white text-xl mb-4 shadow-lg group-hover:scale-110 transition-transform duration-300">
-                                        <i class="fab fa-linkedin-in"></i>
-                                    </div>
-                                    <h4 class="text-gray-800 dark:text-white font-semibold mb-2">LinkedIn</h4>
-                                    <p class="text-gray-600 dark:text-gray-300 text-sm mb-4">Professional network</p>
-                                    <!-- LinkedIn link removed -->
-                                </div>
-                            </div>
-                        </div>
+
                         
                         <!-- GitHub Card -->
                         <div class="group">


### PR DESCRIPTION
Removed LinkedIn contact card and updated grid layout to completely eliminate LinkedIn references.

---
<a href="https://cursor.com/background-agent?bcId=bc-c27d09ab-b682-4d05-86af-95b17af73b2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c27d09ab-b682-4d05-86af-95b17af73b2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

